### PR TITLE
Fixed not being able to spawn an L block

### DIFF
--- a/js/piece.js
+++ b/js/piece.js
@@ -28,6 +28,7 @@ Piece.fromIndex = function(index){
                 [1, 1, 1],
                 [0, 0, 0]
             ]);
+            break;
         case 3: // Z
             piece = new Piece([
                 [1, 1, 0],


### PR DESCRIPTION
There is an error in the block spawning function where whenever it tries to spawn an L block, due to a missing break; statement in the switch-case, it spawns a Z block instead.
