### PR TITLE
fixed slice/splice issue

### DIFF
--- a/js/tuner.js
+++ b/js/tuner.js
@@ -113,7 +113,7 @@ function Tuner(){
     }
 
     function deleteNLastReplacement(candidates, newCandidates){
-        candidates.slice(-newCandidates.length);
+        candidates.splice(-newCandidates.length);
         for(var i = 0; i < newCandidates.length; i++){
             candidates.push(newCandidates[i]);
         }


### PR DESCRIPTION
This fixes the small typo the code appears to have. Calling slice on a javascript array doesn't actually modify the array. Rather it returns a modified copy of the array. Whereas splice actually modifies the array.